### PR TITLE
Fix issue where a path would not be displayed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,10 +50,12 @@ function link(d, curvature) {
        x2 = xi(curvature),
        x3 = xi(1 - curvature),
        y0 = d.start.y + d.thickness / 2,
-       y1 = d.end.y + d.thickness / 2;
+       y1 = d.end.y + d.thickness / 2,
+       // path will not display if y0 and y1 are equal
+       cp2 = y0 == y1 ? y1 + 0.0001 : y1;
    return "M" + x0 + "," + y0
         + "C" + x2 + "," + y0
-        + " " + x3 + "," + y1
+        + " " + x3 + "," + cp2
         + " " + x1 + "," + y1;
 }
 


### PR DESCRIPTION
A path with equal y positions was sometimes generated, in which case the bezier curve would not be displayed. Adding a small (non-noticeable) amount to one of the control points seemed a reasonable solution.

If you merge this, do you think you'd be able to cut a new release? That would be super useful for me!